### PR TITLE
Add Odysee support

### DIFF
--- a/config.template.yml
+++ b/config.template.yml
@@ -47,3 +47,7 @@ methods:
   removededm:
     title: Removed.edm
     enabled: true
+
+  odysee:
+    title: Odysee
+    enabled: true


### PR DESCRIPTION
Adds a check for whether a video has been mirrored to Odysee. This is achieved by querying the LBRY YouTube Sync API.

## Testing

Video IDs this can be tested with:

* 4eGxqPFkppU
* w6Odrz3R3J0