### PR TITLE
Change type name

### DIFF
--- a/lostmediafinder/finder.py
+++ b/lostmediafinder/finder.py
@@ -476,7 +476,7 @@ class removededm(YouTubeService):
                 yield Link(
                     url = link,
                     contains = LinkContains(video = True, metadata = True, thumbnail = True),
-                    title = "Wiki page"
+                    title = "Metadata"
                 )
             rawraw = response.status
 

--- a/lostmediafinder/finder.py
+++ b/lostmediafinder/finder.py
@@ -475,7 +475,7 @@ class removededm(YouTubeService):
             if archived:
                 yield Link(
                     url = link,
-                    contains = LinkContains(video = True, metadata = True, thumbnail = True),
+                    contains = LinkContains(metadata = True),
                     title = "Metadata"
                 )
             rawraw = response.status


### PR DESCRIPTION
RemovedEDM usually doesn't refer to itself as a "wiki", so calling the video page a "wiki page" isn't really ideal.
Also removed the "video" and "thumbnail" values from the metadata page tooltip as they already have their own links displayed.